### PR TITLE
platformをx86_64に指定

### DIFF
--- a/next/Dockerfile.prod
+++ b/next/Dockerfile.prod
@@ -18,7 +18,7 @@ COPY . .
 RUN npm run build
 
 # --- Run Stage ---
-FROM node:19.4.0-alpine
+FROM --platform=linux/x86_64 node:19.4.0-alpine
 
 # Set the working directory
 WORKDIR /app


### PR DESCRIPTION
ローカルのホストマシンがAppleシリコン(arm64)であり、AWSのホストマシンと異なるためエラーが発生した。
ビルドステージではplatformを指定していたが、実行ステージでは指定できておらず、ローカルでイメージをビルドした際に、platformがarm64(aarch64)で作成されてしまったと考える。